### PR TITLE
Fix that let's JwtSecurityTokenHandlerWrapper call ValidateToken with original jwt payload

### DIFF
--- a/IdentityModel/Thinktecture.IdentityModel.Tests/Thinktecture.IdentityModel.45.Tests.csproj
+++ b/IdentityModel/Thinktecture.IdentityModel.Tests/Thinktecture.IdentityModel.45.Tests.csproj
@@ -43,9 +43,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.1.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.3.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/IdentityModel/Thinktecture.IdentityModel.Tests/packages.config
+++ b/IdentityModel/Thinktecture.IdentityModel.Tests/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="4.5.8" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="1.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="3.0.0" targetFramework="net45" />
 </packages>

--- a/IdentityModel/Thinktecture.IdentityModel/Properties/AssemblyInfo.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Properties/AssemblyInfo.cs
@@ -33,8 +33,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.6.1")]
-[assembly: AssemblyFileVersion("3.6.1")]
+[assembly: AssemblyVersion("3.6.1.1")]
+[assembly: AssemblyFileVersion("3.6.1.1")]
 
 [assembly: CLSCompliant(true)]
 [assembly: InternalsVisibleTo("Thinktecture.IdentityModel.Tests")]

--- a/IdentityModel/Thinktecture.IdentityModel/Thinktecture.IdentityModel.45.csproj
+++ b/IdentityModel/Thinktecture.IdentityModel/Thinktecture.IdentityModel.45.csproj
@@ -182,8 +182,9 @@
     </Reference>
     <Reference Include="System.IdentityModel.Selectors" />
     <Reference Include="System.identitymodel.services" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.1.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.3.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/IdentityModel/Thinktecture.IdentityModel/Tokens/JwtSecurityTokenHandlerWrapper.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Tokens/JwtSecurityTokenHandlerWrapper.cs
@@ -26,7 +26,7 @@ namespace Thinktecture.IdentityModel.Tokens
         public override System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Claims.ClaimsIdentity> ValidateToken(SecurityToken token)
         {
             var jwt = token as JwtSecurityToken;
-            var list = new List<ClaimsIdentity>(this.ValidateToken(jwt, validationParams).Identities);
+            var list = new List<ClaimsIdentity>(this.ValidateToken(jwt.RawData, validationParams).Identities);
             return list.AsReadOnly();
         }
 

--- a/IdentityModel/Thinktecture.IdentityModel/packages.config
+++ b/IdentityModel/Thinktecture.IdentityModel/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="1.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="3.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Uses new 3.0.0.0 Microsoft JSON Token Handler and
it has a fix that passes jwt.RawData to the Microsoft ValidateToken()
Method in order to bypass original behavior that passes JwtSecurityToken
which is free of escapes and therefore leads to validation errors if
incoming jwt token has escapes!

Please take a look at issue #141

Many thanks for taking a look into this!

Regards
Luciano
