### PR TITLE
Update to System.IdentityModel.Tokens.Jwt v4.0.0

### DIFF
--- a/IdentityModel/Thinktecture.IdentityModel.Tests/Thinktecture.IdentityModel.45.Tests.csproj
+++ b/IdentityModel/Thinktecture.IdentityModel.Tests/Thinktecture.IdentityModel.45.Tests.csproj
@@ -43,9 +43,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.1.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/IdentityModel/Thinktecture.IdentityModel.Tests/packages.config
+++ b/IdentityModel/Thinktecture.IdentityModel.Tests/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="4.5.8" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="1.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
 </packages>

--- a/IdentityModel/Thinktecture.IdentityModel/Clients/OpenIdConnect/OidcClient.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Clients/OpenIdConnect/OidcClient.cs
@@ -107,11 +107,13 @@ namespace Thinktecture.IdentityModel.Clients
             var parameters = new TokenValidationParameters
             {
                 ValidIssuer = issuer,
-                AllowedAudience = audience,
-                SigningToken = new X509SecurityToken(signingCertificate)
+                ValidAudience = audience,
+                IssuerSigningToken = new X509SecurityToken(signingCertificate)
             };
 
-            return handler.ValidateToken(token, parameters).Claims;
+            SecurityToken wat = null;
+
+            return handler.ValidateToken(token, parameters, out wat).Claims;
         }
 
         public async static Task<IEnumerable<Claim>> GetUserInfoClaimsAsync(Uri userInfoEndpoint, string accessToken)

--- a/IdentityModel/Thinktecture.IdentityModel/Constants/JwtConstants.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Constants/JwtConstants.cs
@@ -7,7 +7,7 @@ namespace Thinktecture.IdentityModel.Constants
 {
     public static class JwtConstants
     {
-        public const string JWT = "JWT";
+//        public const string JWT = "JWT";
         public const string Bearer = "Bearer";
 
         public static class SignatureAlgorithms

--- a/IdentityModel/Thinktecture.IdentityModel/Thinktecture.IdentityModel.45.csproj
+++ b/IdentityModel/Thinktecture.IdentityModel/Thinktecture.IdentityModel.45.csproj
@@ -183,7 +183,7 @@
     <Reference Include="System.IdentityModel.Selectors" />
     <Reference Include="System.identitymodel.services" />
     <Reference Include="System.IdentityModel.Tokens.Jwt">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.1.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <HintPath>..\..\..\..\devtfs\CT\Trunk\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/IdentityModel/Thinktecture.IdentityModel/Tokens/Http/AuthenticationConfigurationExtensionsCore.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Tokens/Http/AuthenticationConfigurationExtensionsCore.cs
@@ -42,15 +42,15 @@ namespace Thinktecture.IdentityModel.Tokens.Http
         {
             var validationParameters = new TokenValidationParameters()
             {
-                AllowedAudience = audience,
-                SigningToken = new BinarySecretSecurityToken(Convert.FromBase64String(signingKey)),
+                ValidAudience = audience,
+                IssuerSigningToken = new BinarySecretSecurityToken(Convert.FromBase64String(signingKey)),
                 ValidIssuer = issuer,
             };
 
             configuration.AddJsonWebToken(
                 validationParameters,
-                AuthenticationOptions.ForAuthorizationHeader(JwtConstants.Bearer),
-                AuthenticationScheme.SchemeOnly(JwtConstants.Bearer),
+                AuthenticationOptions.ForAuthorizationHeader(Constants.JwtConstants.Bearer),
+                AuthenticationScheme.SchemeOnly(Constants.JwtConstants.Bearer),
                 claimMappings);
         }
 
@@ -64,8 +64,8 @@ namespace Thinktecture.IdentityModel.Tokens.Http
         {
             var validationParameters = new TokenValidationParameters()
             {
-                AllowedAudience = audience,
-                SigningToken = new BinarySecretSecurityToken(Convert.FromBase64String(signingKey)),
+                ValidAudience = audience,
+                IssuerSigningToken = new BinarySecretSecurityToken(Convert.FromBase64String(signingKey)),
                 ValidIssuer = issuer,
             };
 
@@ -85,15 +85,15 @@ namespace Thinktecture.IdentityModel.Tokens.Http
         {
             var validationParameters = new TokenValidationParameters()
             {
-                AllowedAudience = audience,
-                SigningToken = new X509SecurityToken(signingCertificate),
+                ValidAudience = audience,
+                IssuerSigningToken = new X509SecurityToken(signingCertificate),
                 ValidIssuer = issuer,
             };
 
             configuration.AddJsonWebToken(
                 validationParameters,
-                AuthenticationOptions.ForAuthorizationHeader(JwtConstants.Bearer),
-                AuthenticationScheme.SchemeOnly(JwtConstants.Bearer),
+                AuthenticationOptions.ForAuthorizationHeader(Constants.JwtConstants.Bearer),
+                AuthenticationScheme.SchemeOnly(Constants.JwtConstants.Bearer),
                 claimMappings);
         }
 
@@ -107,8 +107,8 @@ namespace Thinktecture.IdentityModel.Tokens.Http
         {
             var validationParameters = new TokenValidationParameters()
             {
-                AllowedAudience = audience,
-                SigningToken = new X509SecurityToken(signingCertificate),
+                ValidAudience = audience,
+                IssuerSigningToken = new X509SecurityToken(signingCertificate),
                 ValidIssuer = issuer,
             };
 
@@ -250,8 +250,8 @@ namespace Thinktecture.IdentityModel.Tokens.Http
         {
             var validationParameters = new TokenValidationParameters()
             {
-                AllowedAudience = audienceUri,
-                SigningToken = new X509SecurityToken(signingCertificate),
+                ValidAudience = audienceUri,
+                IssuerSigningToken = new X509SecurityToken(signingCertificate),
                 ValidIssuer = issuerName,
             };
 

--- a/IdentityModel/Thinktecture.IdentityModel/Tokens/Http/HttpAuthentication.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Tokens/Http/HttpAuthentication.cs
@@ -144,12 +144,17 @@ namespace Thinktecture.IdentityModel.Tokens.Http
                             var validationParameters = new TokenValidationParameters
                             {
                                 ValidIssuer = Configuration.SessionToken.IssuerName,
-                                AllowedAudience = Configuration.SessionToken.Audience,
-                                SigningToken = new BinarySecretSecurityToken(Configuration.SessionToken.SigningKey),
+                                ValidAudience = Configuration.SessionToken.Audience,
+                                IssuerSigningToken = new BinarySecretSecurityToken(Configuration.SessionToken.SigningKey),
                             };
 
                             var handler = new JwtSecurityTokenHandler();
-                            return handler.ValidateToken(token, validationParameters);
+
+                            SecurityToken wat;
+
+                            string jwt = handler.WriteToken(token);
+
+                            return handler.ValidateToken(jwt, validationParameters, out wat);
                         }
                     }
                 }
@@ -276,7 +281,8 @@ namespace Thinktecture.IdentityModel.Tokens.Http
                 issuer: Configuration.SessionToken.IssuerName,
                 audience: Configuration.SessionToken.Audience,
                 claims: claims,
-                lifetime: new Lifetime(DateTime.UtcNow, DateTime.UtcNow.Add(Configuration.SessionToken.DefaultTokenLifetime)),
+                notBefore : DateTime.UtcNow,
+                expires : DateTime.UtcNow.Add(Configuration.SessionToken.DefaultTokenLifetime),
                 signingCredentials: new HmacSigningCredentials(Configuration.SessionToken.SigningKey));
 
             var handler = new JwtSecurityTokenHandler();

--- a/IdentityModel/Thinktecture.IdentityModel/Tokens/JwtSecurityTokenHandlerWrapper.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Tokens/JwtSecurityTokenHandlerWrapper.cs
@@ -26,7 +26,12 @@ namespace Thinktecture.IdentityModel.Tokens
         public override System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Claims.ClaimsIdentity> ValidateToken(SecurityToken token)
         {
             var jwt = token as JwtSecurityToken;
-            var list = new List<ClaimsIdentity>(this.ValidateToken(jwt, validationParams).Identities);
+
+            var jwtString = this.WriteToken(jwt);
+
+            SecurityToken wat;
+
+            var list = new List<ClaimsIdentity>(this.ValidateToken(jwtString, validationParams, out wat).Identities);
             return list.AsReadOnly();
         }
 

--- a/IdentityModel/Thinktecture.IdentityModel/packages.config
+++ b/IdentityModel/Thinktecture.IdentityModel/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="1.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hello,

I have an MVC4 app that uses the latest version (v4.0.0) of System.IdentityModel.Tokens.Jwt. I'd like to use the CORS pieces of Thinktecture.IdentityModel.45 in my app, but I can't seem to get that going unless both are on the latest System.IdentityModel.Tokens.Jwt package.

This PR updates to the latest version.
