### PR TITLE
Check for algorthim used when validating Jwt token to avoid race condition

### DIFF
--- a/IdentityModel/Thinktecture.IdentityModel/Tokens/Http/HttpAuthentication.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Tokens/Http/HttpAuthentication.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel.Security.Tokens;
 
@@ -147,6 +148,12 @@ namespace Thinktecture.IdentityModel.Tokens.Http
                                 AllowedAudience = Configuration.SessionToken.Audience,
                                 SigningToken = new BinarySecretSecurityToken(Configuration.SessionToken.SigningKey),
                             };
+
+                            // Create provider to ensure that CrptoHelper.GetIdentityFromConfig has
+                            // loaded and avoid race condition see https://connect.microsoft.com/VisualStudio/feedback/details/1477048/system-identitymodel-cryptohelper-getidentityfromconfig-has-race-condition-issue-that-results-in-miseading-error-message
+                            RSACryptoServiceProvider rsaProvider = new RSACryptoServiceProvider();
+                            RsaSecurityKey rsaKey = new RsaSecurityKey(rsaProvider);
+                            rsaKey.IsSupportedAlgorithm(token.SignatureAlgorithm);
 
                             var handler = new JwtSecurityTokenHandler();
                             return handler.ValidateToken(token, validationParameters);


### PR DESCRIPTION
Whilst using IdentityModel.45 in Loupe we ran into an issue on apppool restarts where we were getting a 401 from IdentityModel but subsequent requests made after that succeeded.

After some investigation we found the issue was related to a problem in System.IdentityModel.Jwt.Tokens in its use of CrptoHelper.GetIdentityFromConfig which can suffer from a race condition, [details here](https://connect.microsoft.com/VisualStudio/feedback/details/1477048/system-identitymodel-cryptohelper-getidentityfromconfig-has-race-condition-issue-that-results-in-miseading-error-message), so we implemented the work around with a minor change so that it isn't just trying to load the one algorthim.

The solution does appear to have worked for us and we no longer have the issue of failing on first request.
