### PR TITLE
We have modified the identity model code to authenticate user using cookie.

### DIFF
--- a/IdentityModel/Thinktecture.IdentityModel/Tokens/Http/AuthenticationConfiguration.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Tokens/Http/AuthenticationConfiguration.cs
@@ -136,6 +136,16 @@ namespace Thinktecture.IdentityModel.Tokens.Http
             return (handler != null);
         }
 
+        public bool TryGetCookieMapping(string cookieName, out SecurityTokenHandlerCollection handler)
+        {
+            handler = (from m in Mappings
+                       where m.Options.RequestType == HttpRequestType.Cookie
+                              && m.Options.Name == cookieName
+                       select m.TokenHandler).SingleOrDefault();
+
+            return (handler != null);
+        }
+
         public bool TryGetClientCertificateMapping(out SecurityTokenHandlerCollection handler)
         {
             handler = (from m in Mappings


### PR DESCRIPTION
In our case, the token was stored in cookie and used to set as header in each API request. Now we are marking cookies as `httpOnly & secure`, so only server will be able to read & modify it. Since passing the token over query string will not be secure, we are passing it through cookie.
We found that the property `HasCookieMapping` is already present in the code, but never implemented to Authenticate a user.
We have added the code to read all cookies and using the AuthenticationOptionMapping to check if cookie with provided mapping exists or not. If the cookie exists, we have returned the SecurityTokenHandlerCollection similar to `TryGetQueryStringMapping`

We referred this blog https://leastprivilege.com/2013/04/22/asp-net-web-api-security-the-thinktecture-identitymodel-authenticationhandler/
However it appears that, the functionality to authenticate using cookie is not available out of the box. We would like to know, if it was missed or deliberately removed, if it’s removed, any particular reason behind it?

Sending a pull request so that others may be benefitted.

Thanks.
